### PR TITLE
Refactor handling of output fastq file handles

### DIFF
--- a/fastq_demux/writer.py
+++ b/fastq_demux/writer.py
@@ -1,8 +1,9 @@
 
-import gzip
+import os
 
-from typing import List, Optional, TextIO
+from typing import Dict, List, Optional, TextIO
 from fastq_demux.parser import FastqFileParser
+
 
 class FastqFileWriter:
 
@@ -22,3 +23,53 @@ class FastqFileWriter:
 
     def write_record(self, record: List[str]) -> None:
         self.fastq_file_handle.write("\n".join(record + [""]))
+
+
+class FastqFileWriterHandler:
+
+    def __init__(
+            self,
+            prefix: str,
+            outdir: str,
+            is_single_end: bool,
+            no_gzip_compression: bool):
+
+        self.prefix: str = prefix
+        self.outdir: str = outdir
+        self.is_single_end: bool = is_single_end
+        self.no_gzip_compression: bool = no_gzip_compression
+
+        self.fastq_file_writers: Optional[Dict[str, List[FastqFileWriter]]] = None
+
+    def fastq_file_name_from_sample_id(
+            self, sample_id: str, barcode: str) -> List[str]:
+        ext: str = "fastq.gz" if not self.no_gzip_compression else "fastq"
+        return [
+            os.path.join(
+                self.outdir,
+                f"{self.prefix}{sample_id}_{barcode.replace('+', '-')}_R{read_no}.{ext}"
+            ) for read_no in range(1, 3 - int(self.is_single_end))]
+
+    def fastq_file_writers_from_sample_id(
+            self, sample_id: str, barcode: str) -> List[FastqFileWriter]:
+        return [
+            FastqFileWriter(fastq_file)
+            for fastq_file in self.fastq_file_name_from_sample_id(
+                sample_id,
+                barcode)]
+
+    def fastq_file_writers_from_mapping(
+            self,
+            barcode_to_sample_mapping: Dict[str, str]) -> Dict[str, List[FastqFileWriter]]:
+
+        if not self.fastq_file_writers:
+            self.fastq_file_writers: Dict[str, List[FastqFileWriter]] = dict()
+            for barcode, sample_id in barcode_to_sample_mapping.items():
+                self.fastq_file_writers[barcode] = \
+                    self.fastq_file_writers_from_sample_id(sample_id, barcode)
+
+        return self.fastq_file_writers
+
+    def write_fastq_record(self, barcode: str, fastq_record: List[List[str]]) -> None:
+        for read_no, record in enumerate(fastq_record):
+            self.fastq_file_writers[barcode][read_no].write_record(record)

--- a/tests/test_fastq_demux.py
+++ b/tests/test_fastq_demux.py
@@ -17,7 +17,7 @@ class TestFastqDemux:
             "GGGGGGGG+AGATCTCG": ["Sample1", 22, 44.0],
             "GAAGATTT+TTTACTCT": ["Sample2", 5, 10.0],
             "GAAGATTT+AAAACGCC": ["Sample3", 3, 6.0],
-            unknown_barcode: ["Sample"]}
+            unknown_barcode: ["barcode"]}
 
         with tempfile.TemporaryDirectory(prefix="TestFastqDemux") as outdir:
             args = (

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -1,7 +1,13 @@
 
+import os.path
+import pytest
+import tempfile
+from unittest import mock
+
 from .context import fastq_demux
-from fastq_demux.writer import FastqFileWriter
+from fastq_demux.writer import FastqFileWriter, FastqFileWriterHandler
 from fastq_demux.parser import FastqFileParser
+from fastq_demux.demux import FastqDemultiplexer
 
 
 class TestFastqFileWriter:
@@ -13,3 +19,96 @@ class TestFastqFileWriter:
         writer.close_handle()
         parser = FastqFileParser(fastq_output_file_r1)
         assert list(parser.fastq_records()) == [[record[0]] for record in fastq_records]
+
+
+class TestFastqFileWriterHandler:
+
+    def test_fastq_file_name_from_sample_id(self):
+        prefix = "this-is-a-prefix-"
+        outdir = tempfile.gettempdir()
+        barcode = "this-is-a+barcode"
+        sample_id = "this-is-a-sample-id"
+
+        fastq_file_writer_handler = FastqFileWriterHandler(
+            prefix=prefix,
+            outdir=outdir,
+            is_single_end=True,
+            no_gzip_compression=True)
+
+        expected_filename = os.path.join(
+            outdir,
+            f"{prefix}{sample_id}_{barcode.replace('+', '-')}_R1.fastq"
+        )
+
+        assert fastq_file_writer_handler.fastq_file_name_from_sample_id(
+            sample_id, barcode) == [expected_filename]
+
+        fastq_file_writer_handler.is_single_end = False
+        fastq_file_writer_handler.no_gzip_compression = False
+
+        expected_filename = f"{expected_filename}.gz"
+
+        assert fastq_file_writer_handler.fastq_file_name_from_sample_id(
+            sample_id, barcode) == [
+                expected_filename,
+                expected_filename.replace("_R1.", "_R2.")]
+
+    def test_fastq_file_writers_from_sample_id_se(self):
+        handler = FastqFileWriterHandler(
+            prefix="", outdir="", is_single_end=True, no_gzip_compression=False)
+        self._helper_fastq_file_writers_from_sample_id(handler)
+
+    def test_fastq_file_writers_from_sample_id_pe(self):
+        handler = FastqFileWriterHandler(
+            prefix="", outdir="", is_single_end=False, no_gzip_compression=False)
+        self._helper_fastq_file_writers_from_sample_id(handler)
+
+    def _helper_fastq_file_writers_from_sample_id(self, handler):
+        with mock.patch("fastq_demux.writer.FastqFileWriter", autospec=True) as writer_mock:
+            sample_id = "this-is-the-sample_id"
+            barcode = "this-is-the-barcode"
+            handler.fastq_file_writers_from_sample_id(sample_id=sample_id, barcode=barcode)
+            assert len(writer_mock.call_args_list) == (2 - int(handler.is_single_end))
+            for read_no, call_args in enumerate(writer_mock.call_args_list):
+                assert sample_id in call_args[0][0]
+                assert barcode in call_args[0][0]
+                assert f"_R{read_no+1}" in call_args[0][0]
+
+    def test_fastq_file_writers_from_mapping(self, samplesheet_parser):
+        handler = FastqFileWriterHandler(
+            prefix="", outdir="", is_single_end=False, no_gzip_compression=False)
+
+        def _fastq_file_writers_from_sample_id(*args):
+            return "-".join(args)
+
+        with mock.patch.object(
+                handler,
+                "fastq_file_writers_from_sample_id",
+                _fastq_file_writers_from_sample_id):
+            barcode_to_sample_mapping = samplesheet_parser.get_barcode_to_sample_mapping()
+            assert handler.fastq_file_writers is None
+            writers = handler.fastq_file_writers_from_mapping(barcode_to_sample_mapping)
+            assert handler.fastq_file_writers == writers
+            for barcode, writer in writers.items():
+                assert barcode in barcode_to_sample_mapping
+                assert writer == "-".join([barcode_to_sample_mapping[barcode], barcode])
+
+    def test_write_fastq_record(self, fastq_writer, fastq_records):
+        # make sure that an unknown barcode throws a KeyError
+        with pytest.raises(KeyError):
+            barcode = FastqDemultiplexer.barcode_from_record(fastq_records[0][0])
+            fastq_writer.write_fastq_record(barcode, fastq_records[0])
+
+        # write the unknown barcode record using the "Unknown" barcode
+        fastq_writer.write_fastq_record("Unknown", fastq_records[0])
+        assert all(
+            [writer.write_record.call_count == 1
+             for writer in fastq_writer.fastq_file_writers["Unknown"]])
+
+        # the rest should have known barcodes
+        for record in fastq_records[1:]:
+            barcode = FastqDemultiplexer.barcode_from_record(record[0])
+            fastq_writer.write_fastq_record(barcode, record)
+            assert all(
+                [writer.write_record.call_count == 1
+                 for writer in fastq_writer.fastq_file_writers[barcode]])


### PR DESCRIPTION
- Refactored handling of file handles for output fastq files in order to make mainly the demux-module classes more single-purpose. 
- In the process, the Demultiplex class could be eliminated and the FastqFileWriterHandler class added
- Updated the test suite accordingly
 